### PR TITLE
fix bug where multiple runs leak theme modules

### DIFF
--- a/src/report/dot/theming.js
+++ b/src/report/dot/theming.js
@@ -1,3 +1,4 @@
+const _cloneDeep = require("lodash/cloneDeep");
 const _get = require("lodash/get");
 const _has = require("lodash/has");
 const DEFAULT_THEME = require("./default-theme.json");
@@ -27,7 +28,7 @@ function determineAttributes(pModuleOrDependency, pAttributeCriteria) {
 }
 
 function normalizeTheme(pTheme) {
-  let lReturnValue = DEFAULT_THEME;
+  let lReturnValue = _cloneDeep(DEFAULT_THEME);
 
   if (pTheme) {
     if (pTheme.replace) {


### PR DESCRIPTION
Every call to cruise with cruiseOptions containing theme modules would leak those theme modules into all subsequent runs because theme modules are modifying DEFAULT_THEME directly.

## Description

DEFAULT_THEME is mutated on e.g. line 40 where `pTheme.modules` are concatenated in. This results in the accumulation of theme modules, corrupting subsequent invocations.

## Motivation and Context

I was running the cruise command programmatically with different theme modules per invocation and noticed the leak, which fundamentally prevents me from using dependency cruiser programmatically. 

## How Has This Been Tested?

I've only done manual inspection of my output at this point. If this PR has interest I'm happy to be pointed towards further testing efforts to solidify the fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/dependency-cruiser/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/dependency-cruiser/blob/develop/.github/CONTRIBUTING.md).
